### PR TITLE
Allow to write in other Flash pages

### DIFF
--- a/STM32F0/luos_hal.c
+++ b/STM32F0/luos_hal.c
@@ -1,6 +1,6 @@
 /******************************************************************************
  * @file luosHAL
- * @brief Luos Hardware Abstration Layer. Describe Low layer fonction 
+ * @brief Luos Hardware Abstration Layer. Describe Low layer fonction
  * @MCU Family STM32FO
  * @author Luos
  * @version 0.0.0
@@ -593,15 +593,18 @@ static void LuosHAL_FlashEraseLuosMemoryInfo(void)
 void LuosHAL_FlashWriteLuosMemoryInfo(uint32_t addr, uint16_t size, uint8_t *data)
 {
     // Before writing we have to erase the entire page
-    // to do that we have to backup current falues by copying it into RAM
+    // to do that we have to backup current values by copying it into RAM
+    uint32_t mask = 0xFFFFFFFFU ^ (PAGE_SIZE-1);
+    uint32_t page_addr = addr & mask; // find the first address of the page
+
     uint8_t page_backup[PAGE_SIZE];
-    memcpy(page_backup, (void *)ADDRESS_ALIASES_FLASH, PAGE_SIZE);
+    memcpy(page_backup, (void *)page_addr, PAGE_SIZE);
 
     // Now we can erase the page
     LuosHAL_FlashEraseLuosMemoryInfo();
 
     // Then add input data into backuped value on RAM
-    uint32_t RAMaddr = (addr - ADDRESS_ALIASES_FLASH);
+    uint32_t RAMaddr = (addr - page_addr);
     memcpy(&page_backup[RAMaddr], data, size);
 
     // and copy it into flash
@@ -610,7 +613,7 @@ void LuosHAL_FlashWriteLuosMemoryInfo(uint32_t addr, uint16_t size, uint8_t *dat
     // ST hal flash program function write data by uint64_t raw data
     for (uint32_t i = 0; i < PAGE_SIZE; i += sizeof(uint64_t))
     {
-        while (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, i + ADDRESS_ALIASES_FLASH, *(uint64_t *)(&page_backup[i])) != HAL_OK)
+        while (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, i + page_addr, *(uint64_t *)(&page_backup[i])) != HAL_OK)
             ;
     }
     HAL_FLASH_Lock();

--- a/STM32F0/luos_hal.c
+++ b/STM32F0/luos_hal.c
@@ -45,7 +45,7 @@ static void LuosHAL_TimeoutInit(void);
 static void LuosHAL_ResetTimeout(void);
 static inline void LuosHAL_ComTimeout(void);
 static void LuosHAL_GPIOInit(void);
-static void LuosHAL_FlashEraseLuosMemoryInfo(void);
+static void LuosHAL_FlashEraseLuosMemoryInfo(uint32_t page_addr);
 static inline void LuosHAL_ComReceive(void);
 static inline void LuosHAL_GPIOProcess(uint16_t GPIO);
 static void LuosHAL_RegisterPTP(void);
@@ -571,13 +571,13 @@ static void LuosHAL_FlashInit(void)
  * @param None
  * @return None
  ******************************************************************************/
-static void LuosHAL_FlashEraseLuosMemoryInfo(void)
+static void LuosHAL_FlashEraseLuosMemoryInfo(uint32_t page_addr)
 {
     uint32_t page_error = 0;
     FLASH_EraseInitTypeDef s_eraseinit;
 
     s_eraseinit.TypeErase = FLASH_TYPEERASE_PAGES;
-    s_eraseinit.PageAddress = ADDRESS_LAST_PAGE_FLASH;
+    s_eraseinit.PageAddress = page_addr;
     s_eraseinit.NbPages = 1;
 
     // Erase Page
@@ -601,7 +601,7 @@ void LuosHAL_FlashWriteLuosMemoryInfo(uint32_t addr, uint16_t size, uint8_t *dat
     memcpy(page_backup, (void *)page_addr, PAGE_SIZE);
 
     // Now we can erase the page
-    LuosHAL_FlashEraseLuosMemoryInfo();
+    LuosHAL_FlashEraseLuosMemoryInfo(page_addr);
 
     // Then add input data into backuped value on RAM
     uint32_t RAMaddr = (addr - page_addr);

--- a/STM32L4/luos_hal.c
+++ b/STM32L4/luos_hal.c
@@ -593,15 +593,18 @@ static void LuosHAL_FlashEraseLuosMemoryInfo(void)
 void LuosHAL_FlashWriteLuosMemoryInfo(uint32_t addr, uint16_t size, uint8_t *data)
 {
     // Before writing we have to erase the entire page
-    // to do that we have to backup current falues by copying it into RAM
+    // to do that we have to backup current values by copying it into RAM
+    uint32_t mask = 0xFFFFFFFFU ^ (PAGE_SIZE-1);
+    uint32_t page_addr = addr & mask; // find the first address of the page
+
     uint8_t page_backup[PAGE_SIZE];
-    memcpy(page_backup, (void *)ADDRESS_ALIASES_FLASH, PAGE_SIZE);
+    memcpy(page_backup, (void *)page_addr, PAGE_SIZE);
 
     // Now we can erase the page
     LuosHAL_FlashEraseLuosMemoryInfo();
 
     // Then add input data into backuped value on RAM
-    uint32_t RAMaddr = (addr - ADDRESS_ALIASES_FLASH);
+    uint32_t RAMaddr = (addr - page_addr);
     memcpy(&page_backup[RAMaddr], data, size);
 
     // and copy it into flash
@@ -610,7 +613,7 @@ void LuosHAL_FlashWriteLuosMemoryInfo(uint32_t addr, uint16_t size, uint8_t *dat
     // ST hal flash program function write data by uint64_t raw data
     for (uint32_t i = 0; i < PAGE_SIZE; i += sizeof(uint64_t))
     {
-        while (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, i + ADDRESS_ALIASES_FLASH, *(uint64_t *)(&page_backup[i])) != HAL_OK)
+        while (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, i + page_addr, *(uint64_t *)(&page_backup[i])) != HAL_OK)
             ;
     }
     HAL_FLASH_Lock();


### PR DESCRIPTION
I wanted to re-use Luos' function to write in Flash but at a different address than the one of the last page. The way `LuosHAL_FlashWriteLuosMemoryInfo` was implemented didn't allow me to do so, so I propose this modification that makes it possible.